### PR TITLE
Depend on matplotlib-base to avoid pyqt dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and py27]
   detect_binary_files_with_prefix: False
 
@@ -42,7 +42,7 @@ requirements:
     - cython >=0.22,!=0.25.1
     - setuptools
     - scipy
-    - matplotlib
+    - matplotlib-base
     - arviz  # [py>=35]
     - libpython  # [win]
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Basically, `matplotlib` = `matplotlib-base` + `pyqt`.  There are lots of packages, this one included, which depend on `matplotlib` and unnecessarily force conda to install qt, which is an extra 100MB.  For more background, see https://github.com/jupyter/docker-stacks/pull/896#issuecomment-515888808 .